### PR TITLE
fix: small bugs

### DIFF
--- a/src/models/deposit.rs
+++ b/src/models/deposit.rs
@@ -15,6 +15,7 @@ pub struct DepositDocument {
     pub vout: u32,
     pub rune: Rune,
     pub amount: String,
+    pub bitcoin_deposit_addr: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/server/claim_deposit_data.rs
+++ b/src/server/claim_deposit_data.rs
@@ -255,6 +255,7 @@ pub async fn claim_deposit_data(
                 vout,
                 rune: tx_data.rune,
                 amount,
+                bitcoin_deposit_addr,
             },
         )
         .await

--- a/src/state/database.rs
+++ b/src/state/database.rs
@@ -207,7 +207,24 @@ impl DatabaseExt for Database {
         deposit: DepositDocument,
     ) -> Result<(), DatabaseError> {
         self.collection::<DepositDocument>("claimed_runes_deposits")
-            .insert_one(deposit)
+            .update_one(
+                doc! {"identifier": deposit.identifier },
+                doc! {
+                    "$set":
+                    {
+                        "tx_id": &deposit.tx_id,
+                        "vout": deposit.vout,
+                        "rune": {
+                            "id": &deposit.rune.id,
+                            "name": &deposit.rune.name,
+                            "spaced_name": &deposit.rune.spaced_name,
+                        },
+                        "amount": &deposit.amount,
+                        "bitcoin_deposit_addr": &deposit.bitcoin_deposit_addr,
+                    }
+                },
+            )
+            .upsert(true)
             .session(&mut *session)
             .await
             .map_err(DatabaseError::QueryFailed)?;


### PR DESCRIPTION
- adds `bitcoin_deposit_addr` in `claimed_runes_deposit` (easier when withdrawing if we already have the `bitcoin_deposit_addr`)
- updates `store_deposit` query to upsert instead of inserting else we end up with the same entries multiple times.